### PR TITLE
Add mc-uuid CLI for regenerating Bedrock manifest UUIDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+*.bak

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# uuidregeneration
+# mc-uuid
+
+A tiny CLI to regenerate UUIDs inside a Minecraft Bedrock `manifest.json`.
+
+## Usage
+
+```
+mc-uuid [path/to/manifest.json] [options]
+```
+
+Options:
+
+- `--dry` – print changes without writing
+- `--no-backup` – skip `.bak` file
+- `--pretty=2` – JSON indentation
+- `--only=header|modules` – update only part of the manifest
+- `--seed <string>` – deterministic UUIDs
+- `--quiet` – minimal output
+
+Example:
+
+```
+mc-uuid ./manifest.json
+mc-uuid ./manifest.json --seed my-seed --only=modules --dry
+```

--- a/bin/mc-uuid.js
+++ b/bin/mc-uuid.js
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+const fs = require('fs/promises');
+const path = require('path');
+const { updateManifest } = require('../lib/updateManifest');
+
+function parseArgs(argv) {
+  const opts = { pretty: 2 };
+  const args = [];
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--dry') opts.dry = true;
+    else if (a === '--no-backup') opts.noBackup = true;
+    else if (a === '--quiet') opts.quiet = true;
+    else if (a.startsWith('--pretty=')) opts.pretty = Number(a.split('=')[1]);
+    else if (a === '--pretty') opts.pretty = Number(argv[++i]);
+    else if (a.startsWith('--only=')) opts.only = a.split('=')[1];
+    else if (a === '--only') opts.only = argv[++i];
+    else if (a.startsWith('--seed=')) opts.seed = a.split('=')[1];
+    else if (a === '--seed') opts.seed = argv[++i];
+    else if (a.startsWith('--')) {
+      throw new Error(`Unknown flag: ${a}`);
+    } else {
+      args.push(a);
+    }
+  }
+  return { opts, args };
+}
+
+(async () => {
+  try {
+    const { opts, args } = parseArgs(process.argv.slice(2));
+    const target = path.resolve(args[0] || './manifest.json');
+    let result;
+    try {
+      result = await updateManifest(target, opts);
+    } catch (err) {
+      if (err.code === 'ENOENT') {
+        if (!opts.quiet) console.error(`File not found: ${target}`);
+        process.exit(2);
+      }
+      if (!opts.quiet) console.error(err.message);
+      process.exit(1);
+    }
+
+    const { text, summary, eol } = result;
+
+    if (opts.dry) {
+      if (!opts.quiet) {
+        console.log('[dry-run]');
+        summary.forEach(l => console.log(l));
+      }
+      process.exit(0);
+    }
+
+    if (!opts.quiet) {
+      summary.forEach(l => console.log(l));
+    }
+
+    if (!opts.noBackup) {
+      try {
+        await fs.copyFile(target, target + '.bak');
+        if (!opts.quiet) console.log(`Saved backup: ${path.basename(target)}.bak`);
+      } catch (err) {
+        if (!opts.quiet) console.error('Write error: ' + err.message);
+        process.exit(3);
+      }
+    }
+
+    try {
+      await fs.writeFile(target, text);
+    } catch (err) {
+      if (!opts.quiet) console.error('Write error: ' + err.message);
+      process.exit(3);
+    }
+
+    if (!opts.quiet) {
+      console.log(`Wrote: ${path.basename(target)} (pretty=${opts.pretty}, eol=${JSON.stringify(eol)})`);
+    }
+  } catch (err) {
+    console.error(err.message);
+    process.exit(1);
+  }
+})();

--- a/lib/diff.js
+++ b/lib/diff.js
@@ -1,0 +1,4 @@
+function formatDiff(label, oldVal, newVal) {
+  return `${label} ${oldVal} → ${newVal}`;
+}
+module.exports = { formatDiff };

--- a/lib/updateManifest.js
+++ b/lib/updateManifest.js
@@ -1,0 +1,95 @@
+const fs = require('fs/promises');
+const { v4, v5 } = require('uuid');
+const { formatDiff } = require('./diff');
+
+async function updateManifest(filePath, options = {}) {
+  const pretty = options.pretty || 2;
+  const seed = options.seed;
+  const only = options.only || {};
+  const onlyHeader = only === 'header';
+  const onlyModules = only === 'modules';
+
+  const original = await fs.readFile(filePath, 'utf8');
+  const eol = original.includes('\r\n') ? '\r\n' : '\n';
+
+  let data;
+  try {
+    data = JSON.parse(original);
+  } catch (err) {
+    const match = /position (\d+)/i.exec(err.message);
+    if (match) {
+      const pos = Number(match[1]);
+      const until = original.slice(0, pos);
+      const lines = until.split(/\n/);
+      const line = lines.length;
+      const col = lines[lines.length - 1].length + 1;
+      err.message = `JSON parse error at line ${line} column ${col}`;
+    }
+    err.type = 'parse';
+    throw err;
+  }
+
+  if (!data || typeof data !== 'object') {
+    const err = new Error('Invalid manifest root');
+    err.type = 'schema';
+    throw err;
+  }
+  if (!data.header || typeof data.header !== 'object' || typeof data.header.uuid !== 'string') {
+    const err = new Error('Invalid manifest: missing header.uuid');
+    err.type = 'schema';
+    throw err;
+  }
+  if (!Array.isArray(data.modules)) {
+    const err = new Error('Invalid manifest: missing modules array');
+    err.type = 'schema';
+    throw err;
+  }
+
+  const used = new Set();
+  data.modules.forEach(m => { if (typeof m.uuid === 'string') used.add(m.uuid); });
+  if (onlyModules) {
+    used.add(data.header.uuid);
+  }
+
+  const changes = [];
+
+  function generate(fieldPath) {
+    let attempt = 0;
+    let id;
+    do {
+      if (seed) {
+        const input = `${fieldPath}|${seed}` + (attempt ? `|retry:${attempt}` : '');
+        id = v5(input, v5.DNS);
+      } else {
+        id = v4();
+      }
+      attempt++;
+    } while (used.has(id));
+    used.add(id);
+    return id;
+  }
+
+  if (!onlyModules) {
+    const old = data.header.uuid;
+    used.delete(old);
+    const nu = generate('header.uuid');
+    data.header.uuid = nu;
+    changes.push(formatDiff('header.uuid', old, nu));
+  }
+
+  if (!onlyHeader) {
+    data.modules.forEach((m, i) => {
+      if (typeof m.uuid !== 'string') return;
+      const old = m.uuid;
+      used.delete(old);
+      const nu = generate(`modules[${i}].uuid`);
+      m.uuid = nu;
+      changes.push(formatDiff(`modules[${i}].uuid`, old, nu));
+    });
+  }
+
+  const text = JSON.stringify(data, null, pretty) + eol;
+  return { text, summary: changes, eol };
+}
+
+module.exports = { updateManifest };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,34 @@
+{
+  "name": "mc-uuid",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mc-uuid",
+      "version": "1.0.0",
+      "dependencies": {
+        "uuid": "^9"
+      },
+      "bin": {
+        "mc-uuid": "bin/mc-uuid.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "mc-uuid",
+  "version": "1.0.0",
+  "description": "CLI tool to regenerate UUIDs in Minecraft Bedrock manifests",
+  "bin": {
+    "mc-uuid": "./bin/mc-uuid.js"
+  },
+  "scripts": {
+    "build": "node -e \"console.log('no build')\"",
+    "test": "node test/run.js"
+  },
+  "dependencies": {
+    "uuid": "^9"
+  },
+  "engines": {
+    "node": ">=16"
+  }
+}

--- a/test/fixtures/badJson.json
+++ b/test/fixtures/badJson.json
@@ -1,0 +1,9 @@
+{
+  "format_version": 2,
+  "header": {
+    "name": "Broken",
+    "uuid": "oops",
+    "version": [1, 0, 0]
+  ,
+  "modules": []
+}

--- a/test/fixtures/noHeader.json
+++ b/test/fixtures/noHeader.json
@@ -1,0 +1,7 @@
+{
+  "format_version": 2,
+  "header": {
+    "name": "No Header UUID"
+  },
+  "modules": []
+}

--- a/test/fixtures/valid.json
+++ b/test/fixtures/valid.json
@@ -1,0 +1,12 @@
+{
+  "format_version": 2,
+  "header": {
+    "name": "My Pack",
+    "uuid": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    "version": [1, 0, 0]
+  },
+  "modules": [
+    { "type": "resources", "uuid": "11111111-2222-3333-4444-555555555555", "version": [1, 0, 0] },
+    { "type": "data",      "uuid": "66666666-7777-8888-9999-000000000000", "version": [1, 0, 0] }
+  ]
+}

--- a/test/run.js
+++ b/test/run.js
@@ -1,0 +1,83 @@
+const assert = require('assert');
+const fs = require('fs/promises');
+const path = require('path');
+const os = require('os');
+const { execFile } = require('child_process');
+
+const cli = path.resolve(__dirname, '../bin/mc-uuid.js');
+
+function run(args, opts = {}) {
+  return new Promise((resolve, reject) => {
+    execFile('node', [cli, ...args], opts, (err, stdout, stderr) => {
+      if (err) {
+        err.stdout = stdout;
+        err.stderr = stderr;
+        reject(err);
+      } else {
+        resolve({ stdout, stderr });
+      }
+    });
+  });
+}
+
+(async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'mc-uuid-'));
+  const fixtures = name => path.join(__dirname, 'fixtures', name);
+  const copy = async name => {
+    const src = fixtures(name);
+    const dest = path.join(tmp, 'manifest.json');
+    await fs.copyFile(src, dest);
+    return dest;
+  };
+
+  // happy path
+  {
+    const file = await copy('valid.json');
+    const res = await run([file], { cwd: tmp });
+    const data = JSON.parse(await fs.readFile(file, 'utf8'));
+    assert.notStrictEqual(data.header.uuid, 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
+    assert.ok(res.stdout.includes('header.uuid'));
+    await fs.stat(file + '.bak');
+  }
+
+  // missing header
+  {
+    try {
+      await run([fixtures('noHeader.json')]);
+      assert.fail('should have failed');
+    } catch (err) {
+      assert.strictEqual(err.code, 1);
+    }
+  }
+
+  // malformed json
+  {
+    try {
+      await run([fixtures('badJson.json')]);
+      assert.fail('should have failed');
+    } catch (err) {
+      assert.strictEqual(err.code, 1);
+    }
+  }
+
+  // dry run
+  {
+    const file = await copy('valid.json');
+    const before = await fs.readFile(file, 'utf8');
+    const res = await run([file, '--dry'], { cwd: tmp });
+    assert.ok(res.stdout.startsWith('[dry-run]'));
+    const after = await fs.readFile(file, 'utf8');
+    assert.strictEqual(before, after);
+    try { await fs.stat(file + '.bak'); assert.fail(); } catch {}
+  }
+
+  // seed deterministic
+  {
+    const file = await copy('valid.json');
+    const r1 = await run([file, '--seed', 'abc', '--dry'], { cwd: tmp });
+    const r2 = await run([file, '--seed', 'abc', '--dry'], { cwd: tmp });
+    assert.strictEqual(r1.stdout, r2.stdout);
+  }
+
+  console.log('All tests passed.');
+})();


### PR DESCRIPTION
## Summary
- add `mc-uuid` CLI for updating header and module UUIDs in manifest.json files
- support dry runs, backups, deterministic `--seed` and selective updates
- document usage and provide minimal tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a69b479c58832c93b2add285ff524e